### PR TITLE
Clean before integration test

### DIFF
--- a/cite-gradle-plugin/src/test/kotlin/com/jakewharton/cite/plugin/gradle/ImplementationDetailTest.kt
+++ b/cite-gradle-plugin/src/test/kotlin/com/jakewharton/cite/plugin/gradle/ImplementationDetailTest.kt
@@ -29,6 +29,7 @@ class ImplementationDetailTest {
 			.withProjectDir(fixtureDir)
 			.withDebug(true) // Run in-process.
 			.withArguments(
+				"clean",
 				"assemble",
 				"-PciteVersion=$CiteVersion",
 			)


### PR DESCRIPTION
Otherwise we could read stale files when run locally that only fail on CI.