### PR TITLE
Fix isolated projects violation

### DIFF
--- a/cite-gradle-plugin/src/main/kotlin/com/jakewharton/cite/plugin/gradle/CitePlugin.kt
+++ b/cite-gradle-plugin/src/main/kotlin/com/jakewharton/cite/plugin/gradle/CitePlugin.kt
@@ -58,7 +58,9 @@ public class CitePlugin : KotlinCompilerPluginSupportPlugin {
 	private fun Project.citeApiDependency(): Any {
 		// Indicates when the plugin is applied inside the Cite repo to Cite's own modules. This
 		// changes dependencies from being external Maven coordinates to internal project references.
-		val isInternalBuild = properties["com.jakewharton.cite.internal"].toString() == "true"
+		val isInternalBuild = providers.gradleProperty("com.jakewharton.cite.internal")
+			.getOrElse("false")
+			.toBoolean()
 
 		return if (isInternalBuild) {
 			project(":cite-api")


### PR DESCRIPTION
`project.properties` will do a recursive lookup for the given property upwards through parent projects until it reaches the root project. Since the intent is to look at the root project properties supplied for the whole build by `gradle.properties` file anyways, use `providers.gradleProperty` instead.